### PR TITLE
Revert "Merge pull request #1 from theodi/bugfix-use-right-ruby-and-gemset"

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -58,7 +58,6 @@ projects.each_pair do |project, servername|
   system "ln -sf #{pwd}/#{project} ~/.pow/#{servername}"
 
   Dir.chdir(project.to_s) do
-    system "rvm use .."
     system "bundle"
   end
     


### PR DESCRIPTION
This reverts commit d2458f6c18cfbe28b47585e6aba08def506b2f7c, reversing
changes made to edbd66a56bdb83b65ad04a2aa0918bbcc68c9169.

Erk. So that didn't work. I get the error:

```
RVM is not a function, selecting rubies with 'rvm use ...' will not work.

You need to change your terminal emulator preferences to allow login shell.
Sometimes it is required to use `/bin/bash --login` as the command.
Please visit https://rvm.io/integration/gnome-terminal/ for a example.
```

This is fixable though. Will have a crack after lunch.
